### PR TITLE
Disabled the next step if the goal is not scenario supply challenge

### DIFF
--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1419,18 +1419,22 @@ void cMain::Open(std::ifstream * file)
 	if (result->goal == goal_steelaxe_text)
 	{
 		menu_goals->GetMenuItems()[0]->Check();
+		rbtn_next->Disable();
 	}
 	else if (result->goal == goal_GOTLAP_text)
 	{
 		menu_goals->GetMenuItems()[1]->Check();
+		rbtn_next->Disable();
 	}
 	else if (result->goal == goal_any_percent_text || result->goal == goal_any_percent_text_old)
 	{
 		menu_goals->GetMenuItems()[2]->Check();
+		rbtn_next->Disable();
 	}
 	else if (result->goal == goal_debug_text)
 	{
 		menu_goals->GetMenuItems()[0]->Check();
+		rbtn_next->Disable();
 	}
 	else if (result->goal == scenario_supply_challenge_text)
 	{


### PR DESCRIPTION
![image](https://github.com/theis999/TAS-Helper-for-Factorio/assets/18309265/6962dac3-21fe-4afb-9b4c-ae6290ed16b6)

If the goal is not supply challenge, then the next command is disabled on startup. 