### PR TITLE
Fix crash with walk panel

### DIFF
--- a/src/WalkPanel.cpp
+++ b/src/WalkPanel.cpp
@@ -26,7 +26,7 @@ int cMain::AddWalkScanStartRow()
 		if (!control_types.contains(StepGridData[i].type))
 			return i;
 		
-	return 0;
+	return -1;
 }
 pair<double, double> cMain::AddWalkScanCurrentPosition()
 {


### PR DESCRIPTION
Fix crash on adding walk step through the walk panel when the steps grid is empty