### PR TITLE
New autosave

### DIFF
--- a/src/AutoSaver.cpp
+++ b/src/AutoSaver.cpp
@@ -1,0 +1,229 @@
+#include "AutoSaver.h"
+#include "Shared functions/Functions.h"
+
+AutoSaver::AutoSaver()
+{}
+
+void AutoSaver::Clear()
+{
+	autosave_data.clear();
+}
+
+bool AutoSaver::IsEmpty()
+{
+	return autosave_data.size() > 0;
+}
+
+void AutoSaver::Push(Command c)
+{
+	undo_stack.Push(c);
+	autosave_data.push_back(c);
+}
+
+Command AutoSaver::Pop()
+{
+	if (!autosave_data.empty()) autosave_data.pop_back();
+	return undo_stack.Pop();
+}
+
+Command AutoSaver::PopBack()
+{
+	auto item = undo_stack.PopBack();
+	if (!item.empty()) autosave_data.push_back(item);
+	return item;
+}
+
+bool AutoSaver::Autosave(wxWindow* parent, DialogProgressBar* dialog_progress_bar, string folder_location, vector<bool> auto_list)
+{
+	int total_commands = autosave_data.size();
+	int lines_processed = 0;
+
+	if (!dialog_progress_bar) dialog_progress_bar = new DialogProgressBar(parent, wxID_ANY, "Processing request");
+
+	dialog_progress_bar->set_text("Auto saving");
+	dialog_progress_bar->set_button_enable(false);
+	dialog_progress_bar->set_progress(0);
+	dialog_progress_bar->Show();
+
+	std::ofstream myfile;
+	myfile.open(folder_location);
+
+	myfile << total_commands_indicator << total_commands << std::endl;
+
+	for (int i = 0; i < autosave_data.size(); i++)
+	{
+		auto& c = autosave_data[i];
+		myfile << COMMAND << ";" << i << ";before;" << c.before.size() << ";after;" << c.after.size() << ";" << c.template_name <<";" << std::endl;
+
+		myfile << BEFORE << std::endl;
+		for (auto& stepline : c.before)
+			myfile << stepline.row << ";" << stepline.step.ToString() << std::endl;
+
+		myfile << AFTER << std::endl;
+		for (auto& stepline : c.after)
+			myfile << stepline.row << ";" << stepline.step.ToString() << std::endl;
+
+		lines_processed++;
+
+		if (lines_processed % 10 == 9)
+		{
+			dialog_progress_bar->set_progress(static_cast<float>(lines_processed) / static_cast<float>(total_commands) * 100.0f - 1);
+			wxYield();
+		}
+	}
+
+	myfile << std::endl;
+	myfile.close();
+
+	dialog_progress_bar->set_progress(100);
+
+	if (auto_list[9]) dialog_progress_bar->Close();
+	else dialog_progress_bar->set_button_enable(true);
+
+	return true;
+}
+
+StepLine AutoSaver::read_StepLine(const size_t segment_size, vector<Building> buildingSnapshot, int& buildingsInSnapShot, std::vector<string>::iterator step_segments)
+{
+	Step step(invalidX, 0);
+
+	if (step_segments[2] != "")
+	{
+		step.X = stod(step_segments[2]);
+		step.OriginalX = step.X;
+		step.Y = stod(step_segments[3]);
+		step.OriginalY = step.Y;
+	}
+
+	step.amount = step_segments[4] == "" || step_segments[4] == "All" ? 0 : stoi(step_segments[4]);
+	step.Item = Capitalize(step_segments[5], true);
+	step.orientation = MapStringToOrientation(step_segments[6]);
+	step.Direction = MapStringToOrientation(step_segments[7]);
+	step.Size = step_segments[8] != "" ? stoi(step_segments[8]) : 1;
+	step.Buildings = step_segments[9] != "" ? stoi(step_segments[9]) : 1;
+	step.Comment = segment_size == step_segment_size || segment_size == step_segment_size_without_colour ? step_segments[10] : "";
+	step.colour = segment_size == step_segment_size && step_segments[11] != "" ? wxColour(step_segments[11]) : wxNullColour;
+	step.Modifiers.FromString(segment_size == step_segment_size ? step_segments[12] : "");
+
+	step.type = ToStepType(step_segments[1]);
+	switch (step.type)
+	{
+		case e_build:
+			step.BuildingIndex = Building(step.X, step.Y, Building::Map_BuildingName_to_BuildingType[step.Item], step.orientation);
+			if (buildingsInSnapShot > -1) buildingsInSnapShot = ProcessBuildStep(buildingSnapshot, buildingsInSnapShot, step);
+			break;
+
+		case e_mine:
+			if (buildingsInSnapShot > -1) ProcessMiningStep(buildingSnapshot, buildingsInSnapShot, step);
+			break;
+
+		case e_priority:
+			step.priority.FromString(step_segments[6]);
+
+			// Only here to populate extra parameters in step. Actual validation will be done on script generation
+			if (buildingsInSnapShot > -1) BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
+			break;
+
+		case e_drive:
+			step.riding.FromString(step_segments[6]);
+			break;
+
+		case e_limit:
+		case e_put:
+		case e_take:
+			step.inventory = GetInventoryType(step_segments[6]);
+			// Only here to populate extra parameters in step. Actual validation will be done on script generation
+			if (buildingsInSnapShot > -1) BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
+			break;
+
+		case e_recipe:
+		case e_filter:
+		case e_rotate:
+		case e_launch:
+			// Only here to populate extra parameters in step. Actual validation will be done on script generation
+			if (buildingsInSnapShot > -1) BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
+			break;
+
+		case e_equip:
+			step.inventory = GetInventoryType(step_segments[6]);
+			break;
+
+		case e_game_speed:
+			step.amount *= 100;
+			break;
+
+		default:
+			break;
+	}
+
+	return {stoi(step_segments[0]), step};
+}
+
+bool AutoSaver::update_segment(std::ifstream& file)
+{
+	string line;
+	string segment;
+	std::stringstream data_line;
+
+	if (std::getline(file, line))
+	{
+		data_line.str(line);
+
+		segments.clear();
+		segments.reserve(16);
+
+		while (std::getline(data_line, segment, ';'))
+		{
+			segments.push_back(segment);
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+vector<Command> AutoSaver::OpenAutosave(std::ifstream& file, vector<Building> buildingSnapshot, int& buildingsInSnapShot)
+{
+	update_segment(file);
+	//if (segments.size() < 2) return {};
+	int total_lines = 1;
+	//if (segments[0] == "Autosave_tag")
+		//total_lines = std::stoi(segments[1]);
+
+	Command current;
+	bool is_after = false;
+		
+	while (update_segment(file))
+	{
+		const size_t segment_size = segments.size();
+		if (segment_size > 0 && segments[0] == COMMAND)
+		{
+			current = Command{
+				//.before = segment_size >= 4 ? vector<StepLine>(std::stoi(segments[3])) : vector<StepLine>(),
+				//.after = segment_size >= 6 ? vector<StepLine>(std::stoi(segments[5])) : vector<StepLine>(),
+				.template_name = segment_size >= 7 ? segments[6] : "",
+			};
+			autosave_data.push_back(current);
+		}
+		else if (segment_size > 0 && segments[0] == BEFORE)
+		{
+			is_after = false;
+		}
+		else if (segment_size > 0 && segments[0] == AFTER)
+		{
+			is_after = true;
+		}
+		else if (segment_size >= 10)
+		{
+			auto _buildingsInSnapShot = autosave_data.back().template_name == "" ? buildingsInSnapShot : -1;
+			StepLine stepline = read_StepLine(segment_size, buildingSnapshot, _buildingsInSnapShot, segments.begin());
+			if (is_after) autosave_data.back().after.push_back(stepline);
+			else autosave_data.back().before.push_back(stepline);
+		}
+	}
+
+	for (auto& item : autosave_data) undo_stack.Push(item);
+
+	return autosave_data;
+}

--- a/src/AutoSaver.cpp
+++ b/src/AutoSaver.cpp
@@ -1,23 +1,20 @@
 #include "AutoSaver.h"
 #include "Shared functions/Functions.h"
 
-AutoSaver::AutoSaver()
-{}
+AutoSaver::AutoSaver() {}
 
 void AutoSaver::Clear()
 {
 	autosave_data.clear();
 }
 
-bool AutoSaver::IsEmpty()
-{
-	return autosave_data.size() > 0;
-}
-
 void AutoSaver::Push(Command c)
 {
 	undo_stack.Push(c);
 	autosave_data.push_back(c);
+
+	if (autosave_data.size() >= undo_stack.CAPACITY && autosave_data.size() % 4 == 0)
+		wxMessageBox("Please save as soon as possible.", "Autosave is exceeding capacity");
 }
 
 Command AutoSaver::Pop()

--- a/src/AutoSaver.h
+++ b/src/AutoSaver.h
@@ -11,9 +11,6 @@ public:
 	// Clears the autosave list, without impacting the undo stack. Used when saving FTG
 	void Clear(); 
 	
-	// Test if the autosave list is empty
-	bool IsEmpty(); 
-	
 	// Pushes a new change to both the autosave list and undo stack
 	void Push(Command); 
 	// Removes the most recent element in the autosave list and pops the undo stack

--- a/src/AutoSaver.h
+++ b/src/AutoSaver.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "CommandStack.h"
+#include "TAS save file/SaveTas.h"
+
+class AutoSaver
+{
+public:
+	AutoSaver();
+
+	// Clears the autosave list, without impacting the undo stack. Used when saving FTG
+	void Clear(); 
+	
+	// Test if the autosave list is empty
+	bool IsEmpty(); 
+	
+	// Pushes a new change to both the autosave list and undo stack
+	void Push(Command); 
+	// Removes the most recent element in the autosave list and pops the undo stack
+	Command Pop();
+
+	// Redos the undo stack and puts the new redone element onto the autosave list
+	Command PopBack(); 
+	
+	// Generates a autosave file
+	bool Autosave(
+		wxWindow* parent,
+		DialogProgressBar* dialog_progress_bar,
+		string folder_location,
+		vector<bool> auto_list
+	);
+
+	// Opens a autosavefile and returns its content
+	vector<Command> OpenAutosave(std::ifstream& file, vector<Building> buildingSnapshot, int& buildingsInSnapShot);
+
+	const string COMMAND = "Command", 
+		BEFORE = "Before", 
+		AFTER = "After";
+
+
+private:
+	// Reads a line of segments assuming it is StepLine
+	StepLine read_StepLine(const size_t segment_size, vector<Building> buildingSnapshot, int& buildingsInSnapShot, std::vector<string>::iterator step_segments);
+	
+	// Reads a line of text and puts elements separated by ; into the segments list
+	bool update_segment(std::ifstream& file);
+	vector<string> segments; // Storage for reading the autosave list
+
+	// The autosave list, used to generate a autosave file
+	vector<Command> autosave_data = vector<Command>();
+	
+	// The undo redo structure, used to undo or redo changes
+	CommandStack undo_stack;
+};

--- a/src/CommandStack.cpp
+++ b/src/CommandStack.cpp
@@ -11,16 +11,16 @@ void CommandStack::Push(Command command)
 {
 	if (command.empty()) return;
 	buffer[head] = command;
-	head = (head + 1) % size;
+	head = (head + 1) % CAPACITY;
 	hair = head;
-	tail = head != tail ? tail : (tail + 1) % size;
+	tail = head != tail ? tail : (tail + 1) % CAPACITY;
 }
 
 Command CommandStack::Pop()
 {
 	if (head == tail) 
 		return {{}, {}, ""};
-	head = (head + size - 1) % size;
+	head = (head + CAPACITY - 1) % CAPACITY;
 	return buffer[head];
 }
 
@@ -29,6 +29,6 @@ Command CommandStack::PopBack()
 	if (head == hair)
 		return {{}, {}, ""};
 	int head_copy = head;
-	head = (head + 1) % size;
+	head = (head + 1) % CAPACITY;
 	return buffer[head_copy];
 }

--- a/src/CommandStack.h
+++ b/src/CommandStack.h
@@ -21,9 +21,11 @@ struct Command
 
 class CommandStack
 {
+public:
+	static inline const int CAPACITY = 128;
 private:
-	static inline const int size = 128;
-	Command buffer[size] = {};
+	
+	Command buffer[CAPACITY] = {};
 	int head = 0, tail = 0, hair = 0;
 
 public:

--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -173,6 +173,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="AutoSaver.cpp" />
     <ClCompile Include="cApp.cpp" />
     <ClCompile Include="cMain.cpp" />
     <ClCompile Include="cMain_Focus.cpp" />
@@ -201,6 +202,7 @@
     <ClCompile Include="WalkPanel.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AutoSaver.h" />
     <ClInclude Include="cApp.h" />
     <ClInclude Include="cMain.h" />
     <ClInclude Include="CommandStack.h" />

--- a/src/Factorio-TAS-Generator.vcxproj.filters
+++ b/src/Factorio-TAS-Generator.vcxproj.filters
@@ -1,23 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="cApp.cpp" />
-    <ClCompile Include="cMain.cpp" />
     <ClCompile Include="GenerateScript.cpp" />
     <ClCompile Include="GUI_Base.cpp" />
-    <ClCompile Include="TypePanel.cpp" />
     <ClCompile Include="DialogProgressBar.cpp" />
     <ClCompile Include="SearchUtil.cpp">
       <Filter>Structs</Filter>
     </ClCompile>
-    <ClCompile Include="ShortcutChanger.cpp" />
-    <ClCompile Include="ImportStepsPanel.cpp" />
-    <ClCompile Include="CommandStack.cpp" />
-    <ClCompile Include="SteptypeColour.cpp" />
-    <ClCompile Include="TAS save file\OpenTas.cpp" />
-    <ClCompile Include="TAS save file\SaveTas.cpp" />
-    <ClCompile Include="TemplatePage.cpp" />
-    <ClCompile Include="WalkPanel.cpp" />
     <ClCompile Include="Structures\Step.cpp">
       <Filter>Structs</Filter>
     </ClCompile>
@@ -51,35 +40,56 @@
     <ClCompile Include="cMain_Highlighter.cpp">
       <Filter>cMain</Filter>
     </ClCompile>
-    <ClCompile Include="AutoSaveQueue.cpp">
-      <Filter>util</Filter>
+    <ClCompile Include="AutoSaver.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="TAS save file\OpenTas.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="TAS save file\SaveTas.cpp">
+      <Filter>save</Filter>
+    </ClCompile>
+    <ClCompile Include="cApp.cpp">
+      <Filter>misc</Filter>
+    </ClCompile>
+    <ClCompile Include="WalkPanel.cpp">
+      <Filter>main elements</Filter>
+    </ClCompile>
+    <ClCompile Include="TypePanel.cpp">
+      <Filter>main elements</Filter>
+    </ClCompile>
+    <ClCompile Include="TemplatePage.cpp">
+      <Filter>main elements</Filter>
+    </ClCompile>
+    <ClCompile Include="SteptypeColour.cpp">
+      <Filter>main elements</Filter>
+    </ClCompile>
+    <ClCompile Include="ShortcutChanger.cpp">
+      <Filter>main elements</Filter>
+    </ClCompile>
+    <ClCompile Include="ImportStepsPanel.cpp">
+      <Filter>main elements</Filter>
+    </ClCompile>
+    <ClCompile Include="cMain.cpp">
+      <Filter>cMain</Filter>
+    </ClCompile>
+    <ClCompile Include="CommandStack.cpp">
+      <Filter>save</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="cApp.h" />
-    <ClInclude Include="cMain.h" />
     <ClInclude Include="GenerateScript.h" />
     <ClInclude Include="GUI_Base.h" />
     <ClInclude Include="DialogProgressBar.h" />
-    <ClInclude Include="TypePanel.h" />
     <ClInclude Include="SearchUtil.h">
       <Filter>Structs</Filter>
     </ClInclude>
-    <ClInclude Include="ShortcutChanger.h" />
-    <ClInclude Include="Settings.h" />
-    <ClInclude Include="ImportStepsPanel.h" />
     <ClInclude Include="nlohmann\json.hpp">
       <Filter>misc</Filter>
     </ClInclude>
     <ClInclude Include="resource.h">
       <Filter>misc</Filter>
     </ClInclude>
-    <ClInclude Include="CommandStack.h" />
-    <ClInclude Include="SteptypeColour.h" />
-    <ClInclude Include="Data\utils.h" />
-    <ClInclude Include="TAS save file\OpenTas.h" />
-    <ClInclude Include="TAS save file\SaveTas.h" />
-    <ClInclude Include="TAS save file\TasFileConstants.h" />
     <ClInclude Include="Structures\Building.h">
       <Filter>Structs</Filter>
     </ClInclude>
@@ -122,14 +132,54 @@
     <ClInclude Include="Shared functions\StringFunctions.h">
       <Filter>util</Filter>
     </ClInclude>
-    <ClInclude Include="Structures\StepModifiers.h" />
     <ClInclude Include="StdUtil.h">
       <Filter>util</Filter>
     </ClInclude>
     <ClInclude Include="HighlighterThreads.h">
       <Filter>cMain</Filter>
     </ClInclude>
-    <ClInclude Include="AutoSaveQueue.h" />
+    <ClInclude Include="AutoSaver.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="TAS save file\OpenTas.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="TAS save file\SaveTas.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="TAS save file\TasFileConstants.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="cApp.h">
+      <Filter>misc</Filter>
+    </ClInclude>
+    <ClInclude Include="Data\utils.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="TypePanel.h">
+      <Filter>main elements</Filter>
+    </ClInclude>
+    <ClInclude Include="SteptypeColour.h">
+      <Filter>main elements</Filter>
+    </ClInclude>
+    <ClInclude Include="ShortcutChanger.h">
+      <Filter>main elements</Filter>
+    </ClInclude>
+    <ClInclude Include="ImportStepsPanel.h">
+      <Filter>main elements</Filter>
+    </ClInclude>
+    <ClInclude Include="cMain.h">
+      <Filter>cMain</Filter>
+    </ClInclude>
+    <ClInclude Include="CommandStack.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings.h">
+      <Filter>save</Filter>
+    </ClInclude>
+    <ClInclude Include="Structures\StepModifiers.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\Lua Files\control.lua">
@@ -184,6 +234,12 @@
     </Filter>
     <Filter Include="cMain">
       <UniqueIdentifier>{ab7d1857-bfda-45e3-9eda-3f45647ff7c2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="save">
+      <UniqueIdentifier>{8564934d-e5c8-479b-b4d4-5842627a5b7e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main elements">
+      <UniqueIdentifier>{23b69407-62db-422b-aa9a-db53d4155aa9}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/Factorio-TAS-Generator.vcxproj.filters
+++ b/src/Factorio-TAS-Generator.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="cMain_Highlighter.cpp">
       <Filter>cMain</Filter>
     </ClCompile>
+    <ClCompile Include="AutoSaveQueue.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cApp.h" />
@@ -126,6 +129,7 @@
     <ClInclude Include="HighlighterThreads.h">
       <Filter>cMain</Filter>
     </ClInclude>
+    <ClInclude Include="AutoSaveQueue.h" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\Lua Files\control.lua">

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -143,8 +143,11 @@ void cMain::OnImportStepsIntoStepsIndexBtnClicked(wxCommandEvent& event)
 	if (row != import_steps_into_steps_ctrl->GetValue())
 	{
 		import_steps_into_steps_ctrl->SetValue(row);
-		auto t = new HighlightInputControlChangedThread({import_steps_into_steps_ctrl});
-		t->Run();
+		if (is_started)
+		{
+			auto t = new HighlightInputControlChangedThread({import_steps_into_steps_ctrl});
+			t->Run();
+		}
 	}
 }
 
@@ -158,8 +161,11 @@ void cMain::OnImportStepsIntoStepsIndexBtnRight(wxMouseEvent& event)
 	if (row - totalRows != import_steps_into_steps_ctrl->GetValue())
 	{
 		import_steps_into_steps_ctrl->SetValue(row - totalRows);
-		auto t = new HighlightInputControlChangedThread({import_steps_into_steps_ctrl});
-		t->Run();
+		if (is_started)
+		{
+			auto t = new HighlightInputControlChangedThread({import_steps_into_steps_ctrl});
+			t->Run();
+		}
 	}
 }
 
@@ -258,8 +264,11 @@ void cMain::OnImportStepsIntoStepsBtnClick(wxCommandEvent& event)
 	vector<int> highlight_rows = {};
 	for (int i = 0; i < steps.size(); i++)
 		highlight_rows.push_back(start + i);
-	HighlightRowsThread* t = new HighlightRowsThread(highlight_rows, this);
-	t->Run();
+	if (is_started)
+	{
+		HighlightRowsThread* t = new HighlightRowsThread(highlight_rows, this);
+		t->Run();
+	}
 }
 
 bool cMain::validateTemplateName()

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -257,7 +257,7 @@ void cMain::OnImportStepsIntoStepsBtnClick(wxCommandEvent& event)
 
 	if (import_steps_clear_checkbox->IsChecked()) import_steps_text_import->Clear();
 
-	stack.Push(change);
+	autosaver.Push(change);
 	no_changes = false;
 
 	wxYield();
@@ -344,7 +344,7 @@ void cMain::OnImportStepsIntoTemplateCtrlEnter(wxCommandEvent& event)
 	import_steps_into_template_btn->Enable(false);
 	import_steps_into_template_ctrl->SetForegroundColour(wxColour("Red"));
 
-	stack.Push(change);
+	autosaver.Push(change);
 	no_changes = false;
 }
 

--- a/src/TAS save file/TasFileConstants.h
+++ b/src/TAS save file/TasFileConstants.h
@@ -16,6 +16,7 @@ static const int template_segment_size_without_comment_and_colour = 11;
 static const int template_segment_size_without_comment_and_colour_and_modifiers = 10;
 
 static const string total_steps_indicator = "Total lines:";
+static const string total_commands_indicator = "Total commands:";
 static const string goal_indicator = "Goal:";
 static const string steps_indicator = "Steps:";
 static const string save_groups_indicator = "Groups:";

--- a/src/TemplatePage.cpp
+++ b/src/TemplatePage.cpp
@@ -135,7 +135,7 @@ void cMain::OnDeleteTemplate(bool force)
 		ClearTemplateGrid();
 	}
 
-	stack.Push(change);
+	autosaver.Push(change);
 	no_changes = false;
 }
 void cMain::OnDeleteTemplateRightClicked(wxMouseEvent& event)
@@ -167,7 +167,7 @@ void cMain::OnTemplateAddStepClicked(wxCommandEvent& event)
 	Command change{.template_name = key};
 	change.after.push_back({row, step});
 
-	stack.Push(change);
+	autosaver.Push(change);
 	no_changes = false;
 }
 
@@ -194,7 +194,7 @@ void cMain::OnTemplateChangeStepClicked(wxCommandEvent& event)
 	auto rowNum = *grid_template->GetSelectedRows().begin();
 	change.after.push_back({rowNum, step});
 	template_map[name][rowNum] = step;
-	stack.Push(change);
+	autosaver.Push(change);
 	no_changes = false;
 }
 
@@ -244,7 +244,7 @@ void cMain::TemplateMoveRow(wxGrid* grid, wxComboBox* cmb, bool move_up, map<str
 	}
 
 	UndoRedo(grid, data_list, StepLineToStepBlock(change.after), StepLineToStepBlock(change.before));
-	stack.Push(change);
+	autosaver.Push(change);
 	no_changes = false;
 }
 
@@ -315,7 +315,7 @@ void cMain::OnTemplateAddToStepsListClicked(wxCommandEvent& event)
 		UpdateStepGrid(moveTo++, &step);
 	}
 
-	stack.Push(change);
+	autosaver.Push(change);
 	no_changes = false;
 }
 

--- a/src/WalkPanel.cpp
+++ b/src/WalkPanel.cpp
@@ -45,7 +45,7 @@ void cMain::CreateWalkStep(int x_modifier, int y_modifier)
 
 	auto step = Step(x + increment * x_modifier, y + increment * y_modifier);
 	step.type = e_walk;
-	stack.Push({.after = AddStep(row, step)});
+	autosaver.Push({.after = AddStep(row, step)});
 
 	grid_steps->SelectRow(row);
 	grid_steps->GoToCell(row, 0);

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -147,6 +147,8 @@ cMain::cMain() : GUI_Base(nullptr, wxID_ANY, window_title, wxPoint(30, 30), wxSi
 		Open(&tas_file);
 	}
 	TemplatePageStartup();
+
+	is_started = true;
 }
 
 void cMain::OnStepsGridCellChange(wxGridEvent& event)
@@ -1083,8 +1085,11 @@ void cMain::OnStepsGridRightClick(wxGridEvent& event)
 
 	UpdateParameters(&gridEntry, event);
 
+	if (is_started)
+	{
 	HighlightRowThread* t = new HighlightRowThread(row, this);
 	t->Run();
+}
 }
 
 void cMain::OnStepsGridRangeSelect(wxGridRangeSelectEvent& event)
@@ -2000,7 +2005,7 @@ void cMain::UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event, bool c
 		ctrls.push_back(txt_comment);
 	}
 
-	if (ctrls.size() > 0)
+	if (is_started && ctrls.size() > 0)
 	{
 		auto t = new HighlightInputControlChangedThread(ctrls);
 		t->Run();

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1529,7 +1529,14 @@ void cMain::OnMenuOpen(wxCommandEvent& event)
 #pragma warning(suppress : 4996)
 		std::locale utf8_locale(std::locale(), new std::codecvt_utf8<wchar_t>);
 		file.imbue(utf8_locale);
-		file.open(dlg.GetPath().ToStdString());
+
+		auto path = dlg.GetPath().ToStdString();
+
+		if (path.ends_with("_autosave.txt"))
+			path = wxMessageBox("This file look like an autosave file!\nWould you like to open < " + path.substr(0, path.size() - string("_autosave.txt").size()) + ".txt > instead?",
+				"Open save file instead of autosave?", wxICON_QUESTION | wxYES_NO, this) == wxYES ? path.substr(0, path.size() - string("_autosave.txt").size()) + ".txt" : path;
+
+		file.open(path);
 
 		if (!file)
 		{

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -37,7 +37,7 @@
 #include "Shared functions\Functions.h"
 
 #include "../icon.xpm"
-#include "CommandStack.h"
+#include "AutoSaver.h"
 
 #include "Recipe.h"
 #include "Item.h"
@@ -338,7 +338,7 @@ private:
 	void UndoRedoHandleTemplate(Command command, vector<StepBlock> before, vector<StepBlock> after);
 	void OnUndoMenuSelected(wxCommandEvent& event);
 	void OnRedoMenuSelected(wxCommandEvent& event);
-	CommandStack stack;
+	AutoSaver autosaver;
 	vector<tuple<int, Step>> GetSelectedRowTuples();
 	tuple<int, Step> GetRowTuple(int index);
 	void SelectRowsInGrid(vector<tuple<int, Step>> rows);

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -294,6 +294,8 @@ protected:
 	void OnMainBookPageChanged(wxAuiNotebookEvent& event);
 
 private:
+	bool is_started = false;
+
 	wxString window_title = "Factorio TAS Generator";
 
 	DialogProgressBar* dialog_progress_bar = nullptr;


### PR DESCRIPTION
## New autosave
Based on a Migration system

### Change the autosave from copy based system to a migration based system.
Both systems activate on **script generation**.
The previous autosave system just created copy of the FTG save file with a `_autosave_` and `[1-10]` number postfix. Allowing for up to 10 autosaves.

The new system is more clever, by having a **list of changes** since **last save** and only saving these: on average the autosave file will be much much smaller and thus much faster to save. 
The new system also allows for **applying changes** from the autosave without changing the main save file.
The changes applied by the autosave are loaded into the **Undo/redo stack**, giving access to previous iterations without changing FTG save file.


Once a save occurs, the autosave list will be **flushed**.
Once a autosave occurs, FTG will assume all changes are saved, preventing the save changes dialog from appearing.

### Note
The autosave list has infinite size, which means that the autosave file can become much larger than the save file.
This also means that if your autosave exceeds the 128 buffer size of the Undo/redo stack, you won't be able to undo everything queued up.

### New warnings
Added warning if the autosave list is exceeding the undo/redo stack size, reminding the user to make a full save.
Added warning if the user tries to open a file that looks like a autosave file, ei it ends with `_autosave.txt`. 

### Extra
Updated filter groups
Fixed a crash related to race condition during startup where highlighting threads were interacting with the GUI before it was ready.